### PR TITLE
Fix kfxdedrm discovery on Kindle /mnt/us FUSE mounts

### DIFF
--- a/python/dedrm/native_extractor.py
+++ b/python/dedrm/native_extractor.py
@@ -44,22 +44,37 @@ def _candidate_paths(plugin_dir=None, native_dir=None):
             yield os.path.join(directory, name)
 
 
+def _should_probe_native_binary(path):
+    """Return True when a candidate path should be runtime-probed.
+
+    Kindle firmware mounts /mnt/us over FUSE. Permission and file-type metadata
+    such as os.access(X_OK) or os.path.isfile() can be wrong for shipped
+    kfxdedrm binaries even though execve succeeds. Only skip obvious
+    directories; treat the extractor's own ``test`` command as authoritative.
+    """
+    if os.path.isdir(path):
+        return False
+    return os.path.isfile(path) or os.path.lexists(path)
+
+
+def _probe_native_binary(path):
+    """Run the native extractor compatibility self-test."""
+    return subprocess.run(
+        [path, "test"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
 def find_executable(plugin_dir=None, native_dir=None):
     """Return the first ABI-compatible native extractor executable."""
     failures = []
     for path in _candidate_paths(plugin_dir, native_dir):
-        # /mnt/us is FUSE-mounted on Kindle firmware, and os.access(X_OK) can
-        # report false for binaries that the kernel can execute successfully.
-        # Treat the extractor's own `test` command as the compatibility probe.
-        if not os.path.isfile(path):
+        if not _should_probe_native_binary(path):
             continue
         try:
-            result = subprocess.run(
-                [path, "test"],
-                capture_output=True,
-                text=True,
-                timeout=15,
-            )
+            result = _probe_native_binary(path)
         except (OSError, subprocess.TimeoutExpired) as error:
             failures.append(f"{path}: {error}")
             continue

--- a/python/tests/test_native_extractor.py
+++ b/python/tests/test_native_extractor.py
@@ -42,26 +42,39 @@ class NativeExtractorTests(unittest.TestCase):
 
         self.assertEqual(second, executable)
 
-    def test_find_executable_does_not_trust_fuse_access_check(self):
+    def test_find_executable_probes_without_execute_metadata(self):
+        # Regression for kaikozlov/kindle.koplugin#8: /mnt/us FUSE can make
+        # os.access(X_OK) lie while execve still succeeds.
         with tempfile.TemporaryDirectory() as native_dir:
             candidate = os.path.join(native_dir, native_extractor.CANDIDATE_NAMES[0])
             open(candidate, "wb").close()
 
-            with mock.patch.object(os, "access", return_value=False), \
-                    mock.patch.object(
-                        native_extractor.subprocess,
-                        "run",
-                        return_value=mock.Mock(returncode=0),
-                    ) as run:
+            with mock.patch.object(
+                native_extractor,
+                "_probe_native_binary",
+                return_value=mock.Mock(returncode=0),
+            ) as probe:
                 executable = native_extractor.find_executable(native_dir=native_dir)
 
         self.assertEqual(candidate, executable)
-        run.assert_called_once_with(
-            [candidate, "test"],
-            capture_output=True,
-            text=True,
-            timeout=15,
-        )
+        probe.assert_called_once_with(candidate)
+
+    def test_find_executable_probes_when_isfile_misreports_fuse_path(self):
+        with tempfile.TemporaryDirectory() as native_dir:
+            candidate = os.path.join(native_dir, native_extractor.CANDIDATE_NAMES[0])
+            open(candidate, "wb").close()
+
+            with mock.patch.object(os.path, "isfile", return_value=False), \
+                    mock.patch.object(os.path, "lexists", return_value=True), \
+                    mock.patch.object(
+                        native_extractor,
+                        "_probe_native_binary",
+                        return_value=mock.Mock(returncode=0),
+                    ) as probe:
+                executable = native_extractor.find_executable(native_dir=native_dir)
+
+        self.assertEqual(candidate, executable)
+        probe.assert_called_once_with(candidate)
 
     def test_extract_page_keys_removes_generated_keyfile(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #8

## Problem

On Kindle devices, `/mnt/us` is FUSE-mounted. The native DRM fallback in `python/dedrm/native_extractor.py` previously gated kfxdedrm discovery on `os.access(path, os.X_OK)`, which can return `False` for binaries that the kernel executes successfully. When the primary Java extractor is unavailable (no `/usr/java/bin/cvm`), this caused the plugin to report:

```
native fallback failed: no native extractor binaries found
```

…even with a working `kfxdedrmhf_c11` installed under `/mnt/us/extensions/kfxdedrm/`.

## Fix

- Stop using permission metadata (`os.access(X_OK)`) to decide whether a candidate is runnable.
- Probe each present candidate with the native extractor's own `test` subcommand via `subprocess.run`, which matches real on-device executability.
- Add `_should_probe_native_binary()` to skip directories but still attempt probes when FUSE misreports file type (`os.path.isfile()` false while `os.path.lexists()` true).
- Add regression tests referencing issue #8.

## Verification

**Unit tests**

```sh
cd python && python3 -m unittest tests.test_native_extractor -v
```

**On device (cvm-less Kindle with kfxdedrm installed)**

1. Install kfxdedrm (KUAL extension or kfx-dedrm scriptlet) under `/mnt/us/extensions/`.
2. Deploy a plugin build containing this change.
3. Open a DRM-protected KFX book from the Kindle Library.
4. Confirm DRM extraction succeeds via the native fallback instead of `drm_extractor_unavailable`.

Manual probe (optional):

```sh
/mnt/us/extensions/kfxdedrm/bin/kfxdedrmhf_c11 test
# expect exit code 0
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6dd5ba3e-7c96-42cc-99fb-12509fb746af?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dd5ba3e-7c96-42cc-99fb-12509fb746af&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

